### PR TITLE
Replaced FirefoxDriver with HtmlUnitDriver

### DIFF
--- a/java-example/src/it/java/com/weblogism/cucumberjvm/javaexample/connectors/WebConnector.java
+++ b/java-example/src/it/java/com/weblogism/cucumberjvm/javaexample/connectors/WebConnector.java
@@ -3,7 +3,7 @@ package com.weblogism.cucumberjvm.javaexample.connectors;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -12,7 +12,8 @@ import java.util.concurrent.TimeUnit;
 
 public class WebConnector {
     private final static long DEFAULT_TIMEOUT = 2000;
-    WebDriver driver = new FirefoxDriver();
+    // to visually see the page loaded replace HtmlUnitDriver with FirefoxDriver, ChromeDriver, InternetExplorerDriver, SafariDriver
+    WebDriver driver = new HtmlUnitDriver();
     
     @Before
     public void initSelenium() throws Exception {


### PR DESCRIPTION
In the event that the developer doesn't have Firefox installed, the test
would have failed by default. Now it'll work anywhere. And a comment has
been added to help choose another browser driver.
